### PR TITLE
🩹 [Patch]: Remove module test after its default on Test-PSModule

### DIFF
--- a/tests/Admin.Tests.ps1
+++ b/tests/Admin.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Admin' {
                 }
             }
         ) {
-            Test-Admin | Should -Be $false
+            Test-Admin | Should -Be $expected
         }
     }
 }

--- a/tests/Admin.Tests.ps1
+++ b/tests/Admin.Tests.ps1
@@ -8,30 +8,26 @@ Param(
 Write-Verbose "Path to the module: [$Path]" -Verbose
 
 Describe 'Admin' {
-    Context 'Module' {
-        It 'The module should be available' {
-            Get-Module -Name 'Admin' -ListAvailable | Should -Not -BeNullOrEmpty
-            Write-Verbose (Get-Module -Name 'Admin' -ListAvailable | Out-String) -Verbose
+    Context 'Function: Test-Admin' {
+        It 'Should not throw' {
+            { Test-Admin } | Should -Not -Throw
         }
-        It 'The module should be importable' {
-            { Import-Module -Name 'Admin' -Verbose -RequiredVersion 999.0.0 -Force } | Should -Not -Throw
+
+        It 'Should return <Expected> for <OS> based runners' -ForEach @(
+            @{
+                Expected = if ($IsLinux -or $IsMacOS) {
+                    $false
+                } else {
+                    $true
+                }
+                OS       = if ($IsLinux -or $IsMacOS) {
+                    'Unix'
+                } else {
+                    'Windows'
+                }
+            }
+        ) {
+            Test-Admin | Should -Be $false
         }
     }
-
-    # Commented out as it is difficult to test this function in a CI/CD pipeline
-    # Context 'Function: Test-Admin' {
-    #     It 'should not throw' {
-    #         { Test-Admin } | Should -Not -Throw
-    #     }
-
-    #     It 'should return true' {
-    #         $IsUnix = $PSVersionTable.Platform -eq 'Unix'
-    #         if ($IsUnix) {
-    #             $IsAdmin = $(sudo pwsh -command "Test-Admin")
-    #         } else {
-    #             $IsAdmin = Test-Admin
-    #         }
-    #         $IsAdmin | Should -Be $true
-    #     }
-    # }
 }


### PR DESCRIPTION
## Description

- Remove module test after its default on Test-PSModule, but add in the function test

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
