### PR TITLE
🪲 [Fix]: Remove all but Material selector in mkdocs.yml settings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,12 @@
 site_name: -{{ REPO_NAME }}-
 theme:
   name: material
-  language: en
-  font:
-    text: Roboto
-    code: Sono
-  logo: assets/icon.png
-  favicon: assets/icon.png
+#   language: en
+#   font:
+#     text: Roboto
+#     code: Sono
+#   logo: assets/icon.png
+#   favicon: assets/icon.png
 #   palette:
 #     # Palette toggle for automatic mode
 #     - media: "(prefers-color-scheme)"


### PR DESCRIPTION
## Description

- Remove all but Material selector in mkdocs.yml settings

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
