### PR TITLE
🚀 [Feature]: Restructure for Process-PSModule v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: / # Location of package manifests
     schedule:
       interval: weekly
-  - package-ecosystem: nuget # See documentation for possible values
-    directory: / # Location of package manifests
-    schedule:
-      interval: weekly

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -27,3 +27,5 @@ jobs:
         uses: super-linter/super-linter@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/Nightly-Run.yml
+++ b/.github/workflows/Nightly-Run.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  statuses: write
 
 jobs:
   Process-PSModule:

--- a/.github/workflows/Nightly-Run.yml
+++ b/.github/workflows/Nightly-Run.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/CI.yml@v2
+    uses: PSModule/Process-PSModule/.github/workflows/CI.yml@v3
     secrets: inherit

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -26,5 +26,5 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v2
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v3
     secrets: inherit

--- a/src/functions/public/Test-Admin.ps1
+++ b/src/functions/public/Test-Admin.ps1
@@ -7,6 +7,9 @@
         Test-Role
 
         Test if the current context is running as an Administrator.
+
+        .LINK
+        https://psmodule.io/Admin/Functions/Test-Admin/
     #>
     [OutputType([System.Boolean])]
     [CmdletBinding()]


### PR DESCRIPTION
## Description

- Removing support for Windows PowerShell - directional change for PSModule.
- Remove nuget from Dependabot settings
- Using Process-PSModule v3
- Restructure for v3

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
