### PR TITLE
🩹 [Patch]: Add public `Scope` enum

### DIFF
--- a/src/classes/public/Scope.ps1
+++ b/src/classes/public/Scope.ps1
@@ -1,0 +1,4 @@
+enum Scope {
+    CurrentUser
+    AllUsers
+}


### PR DESCRIPTION
## Description

This pull request introduces an enumeration to the `Scope.ps1` file, which defines two possible values: `CurrentUser` and `AllUsers`. This change likely aims to improve the clarity and manageability of user scope definitions within the script.

* [`src/classes/public/Scope.ps1`](diffhunk://#diff-6fa5021c088076009fbe7134aaa61b0cbc5b4d0a69bb2820873620be00c45f61R1-R4): Added an enum `Scope` with values `CurrentUser` and `AllUsers`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
