### PR TITLE
🪲 [Fix]: Remove `Scope` enum definition

### DIFF
--- a/src/classes/public/Scope.ps1
+++ b/src/classes/public/Scope.ps1
@@ -1,4 +1,0 @@
-enum Scope {
-    CurrentUser
-    AllUsers
-}


### PR DESCRIPTION
## Description

This pull request includes a small change to the `src/classes/public/Scope.ps1` file. The change removes the `Scope` enumeration which contained `CurrentUser` and `AllUsers` values.

* [`src/classes/public/Scope.ps1`](diffhunk://#diff-6fa5021c088076009fbe7134aaa61b0cbc5b4d0a69bb2820873620be00c45f61L1-L4): Removed the `Scope` enumeration.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
