### PR TITLE
🩹 [Patch]: Add PowerShell version to manifest file

### DIFF
--- a/src/manifest.psd1
+++ b/src/manifest.psd1
@@ -1,0 +1,3 @@
+﻿@{
+    PowerShellVersion = '5.1'
+}


### PR DESCRIPTION
## Description

This pull request includes a small change to the `src/manifest.psd1` file. The change specifies the PowerShell version to accept the module.

- As requested on: https://github.com/PSModule/Fonts/issues/40

* [`src/manifest.psd1`](diffhunk://#diff-89820c99acb3b881e314c7e358eea621a8687cb4e0c687f541b9dcc9f30cc5dcR1-R3): Added a PowerShell version attribute to ensure compatibility with PowerShell version 5.1.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
