### PR TITLE
🩹 [Patch]: Add labels to Dependabot configuration for better categorization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,8 @@ version: 2
 updates:
   - package-ecosystem: github-actions # See documentation for possible values
     directory: / # Location of package manifests
+    labels:
+      - dependencies
+      - github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

This pull request introduces a minor configuration update to Dependabot. It adds labels to pull requests created for GitHub Actions dependency updates, making it easier to identify and filter these PRs.

- Dependabot Configuration:
  * [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R12): Added `dependencies` and `github-actions` labels to PRs for GitHub Actions updates.
