### PR TITLE
🩹 [Patch]: Update CodeCoverage PercentTarget to 95

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -4,7 +4,7 @@
 
 Test:
   CodeCoverage:
-    PercentTarget: 0
+    PercentTarget: 95
 #   TestResults:
 #     Skip: true
 #   SourceCode:


### PR DESCRIPTION
## Description

This pull request makes a single, focused change to the `.github/PSModule.yml` configuration file, significantly increasing the code coverage target for tests.

- Increased the `CodeCoverage.PercentTarget` from 0 to 95 in `.github/PSModule.yml`, raising the required test coverage threshold.
