### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,27 @@
 # Admin
 
-A PowerShell module that provides a set of functions to help with checking if the current context is running in elevated mode.
-
-## Prerequisites
-
-This module requires PowerShell 5.1 or later.
+Admin is a PowerShell module for working with administrator role checks.
 
 ## Installation
 
-To install the module run the following:
+Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-Module -Name Admin
+Install-PSResource -Name Admin
 Import-Module -Name Admin
 ```
 
-## Usage
+## Documentation
 
-### Example 1: Test if the current context is running in elevated mode
+Documentation is published at [psmodule.io/Admin](https://psmodule.io/Admin/).
+
+Use PowerShell help and command discovery for module details:
 
 ```powershell
-Test-Admin
-true
+Get-Command -Module Admin
+Get-Help <CommandName> -Examples
 ```
-
-Check if the current context is running in elevated mode.
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Admin is a PowerShell module for working with administrator role checks.
 Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-PSResource -Name Admin
+Install-Module -Name Admin
 Import-Module -Name Admin
 ```
 
@@ -19,7 +19,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Admin
-Get-Help <CommandName> -Examples
+Get-Help Test-Admin -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Admin
 
-Admin is a PowerShell module for checking whether the current session is running in an elevated (administrator) context.
+Admin is a PowerShell module for checking whether the current session is running in an elevated context — as an administrator on Windows, or as root on Linux and macOS.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,31 @@
 # Admin
 
-Admin is a PowerShell module for working with administrator role checks.
+Admin is a PowerShell module for checking whether the current session is running in an elevated (administrator) context.
 
 ## Installation
 
 Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-Module -Name Admin
+Install-PSResource -Name Admin
 Import-Module -Name Admin
+```
+
+## Usage
+
+### Example: Test if the current context is elevated
+
+```powershell
+Test-Admin
+# True
+```
+
+`Test-Admin` returns `$true` when the current session is running with administrator (Windows) or root (Linux/macOS) privileges, otherwise `$false`. Use it to gate operations that require elevation:
+
+```powershell
+if (-not (Test-Admin)) {
+    throw 'This operation requires an elevated session.'
+}
 ```
 
 ## Documentation
@@ -21,7 +38,3 @@ Use PowerShell help and command discovery for module details:
 Get-Command -Module Admin
 Get-Help Test-Admin -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
Admin's README is now a concise landing page that follows the standard PSModule module-README format, so users get what they need at a glance instead of duplicated command reference.

## What changed

- **Usage example restored** — the README now shows how to use `Test-Admin` to detect whether the current session is elevated (administrator/root), including a guard-clause pattern for gating operations that require elevation.
- **Install-PSResource** — installation now uses `Install-PSResource` (the modern PSResourceGet cmdlet) instead of the deprecated `Install-Module`.
- **Contributing section removed** — community/contribution boilerplate no longer lives on the published landing page.
- **Stale content dropped** — the empty `## Acknowledgements` placeholder (no real attribution) and the outdated PowerShell 5.1 prerequisite note were removed.

## Landing-page shape

`# Admin` → one-paragraph overview → `## Installation` → `## Usage` → `## Documentation` (links to [psmodule.io/Admin](https://psmodule.io/Admin/) plus a real `Get-Command`/`Get-Help` discovery snippet).

## Technical details

- Updates `README.md` only.
- Aligns with the module-README standard from `PSModule/Template-PSModule`.
